### PR TITLE
Fixed issue with adding Bubbles and removing

### DIFF
--- a/muPropagate.js
+++ b/muPropagate.js
@@ -110,7 +110,7 @@ function createBubble() {
   iBubble++;
 }
 
-// Add a new Bubble to the array using predefined inuts
+// Add a new Bubble to the array using predefined inputs
 function createNewBubble() {
   var _key = iBubble;
   var _tag = '[tag]';
@@ -119,7 +119,7 @@ function createNewBubble() {
   var _value = 0;
   var _absUn = 0;
   bubbleArray.push(new Bubble(_key, _tag, _group, _unit, _value, _absUn));
-  bubbleArray[iBubble].relUn = 0;
+  bubbleArray[getBubbleIndex(_key)].relUn = 0;
   iBubble++;
 }
 


### PR DESCRIPTION
When a Bubble was removed (i.e. bubbleArray spliced), and when a new one was added afterwards, the bubbleArray would be mistakenly accessed at a Bubble key value instead of an index value. Previously caused unpredictable behavior in the array, and in printing out dynamic DOM elements in updateView().